### PR TITLE
Fix install API

### DIFF
--- a/back/api/installations.php
+++ b/back/api/installations.php
@@ -1,13 +1,9 @@
 <?php
-<<<<<<< Updated upstream
 require_once __DIR__ . '/../core/Database.php';
 require_once __DIR__ . '/../models/InstallationModel.php';
-=======
+
 ini_set('display_errors', 1);
 error_reporting(E_ALL);
-header('Content-Type: text/plain');
-
->>>>>>> Stashed changes
 
 header('Content-Type: application/json');
 
@@ -24,7 +20,7 @@ switch ($method) {
 				'panneau' => $_GET['panneau'] ?? null,
 				'departement' => $_GET['departement'] ?? null,
 			];
-			$data = $model->getAll($filtres);
+                        $data = $model->getInstallations($filtres);
 		}
 		echo json_encode($data);
 		break;


### PR DESCRIPTION
## Summary
- clean up merge conflict markers in installation API
- call correct model method for GET queries

## Testing
- `php -l back/api/installations.php`
- `find back -name '*.php' -maxdepth 2 -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68403f260d9c832981cc149a972e5f7d